### PR TITLE
fix deprecation about escaped reference

### DIFF
--- a/source/evael/ecs/entity.d
+++ b/source/evael/ecs/entity.d
@@ -68,7 +68,7 @@ struct Entity
     @nogc
     @property nothrow
     {
-        public ref const(Id) id() const
+        public ref const(Id) id() const return
         {
             return this.m_id;
         }


### PR DESCRIPTION
solve the error message:
```
source/evael/ecs/entity.d(73,20): Deprecation: returning this.m_id escapes a reference to parameter this, perhaps annotate with return
```